### PR TITLE
fix handling of empty list tags

### DIFF
--- a/lib/craftbook/nbt/list_tag.rb
+++ b/lib/craftbook/nbt/list_tag.rb
@@ -54,7 +54,8 @@ module CraftBook
         child_type = hash[:child_type]
         raise(ParseError, "invalid array") unless values.is_a?(Array)
         raise(ParseError, "invalid child type") unless !child_type.nil? & child_type.between?(TYPE_END, TYPE_LONG_ARRAY)
-
+        return if values.empty?
+        
         klass = Tag.class_from_type(child_type)
         values.each do |value|
           child = klass.allocate


### PR DESCRIPTION
Empty list tags save the child type as "0" which is a tag-type that `class_from_type` cannot map.

If the list is empty, the child-tag-type doesn't matter anyhow, so we can exit early without handling anything children related.

This issue appeared when trying to use `CraftBook::NBT::Tag.from_hash tag.to_h` to deep-clone an existing NBT-tag after reading a schematic file created by the Minecraft mod Structurize